### PR TITLE
Provide default for case

### DIFF
--- a/src/zfscrypt_err.c
+++ b/src/zfscrypt_err.c
@@ -57,7 +57,8 @@ int zfscrypt_err_for_pam(zfscrypt_err_t err) {
         return PAM_SYSTEM_ERR;
     case ZFSCRYPT_ERR_PAM:
         return err.value;
+    default:
+        // unreachable
+        return PAM_SYSTEM_ERR;
     }
-    // unreachable
-    return PAM_SYSTEM_ERR;
 }

--- a/src/zfscrypt_err.c
+++ b/src/zfscrypt_err.c
@@ -52,13 +52,13 @@ int zfscrypt_err_for_pam(zfscrypt_err_t err) {
     if (err.value == 0)
         return PAM_SUCCESS;
     switch (err.type) {
-    case ZFSCRYPT_ERR_OS:
-    case ZFSCRYPT_ERR_ZFS:
-        return PAM_SYSTEM_ERR;
-    case ZFSCRYPT_ERR_PAM:
-        return err.value;
-    default:
-        // unreachable
-        return PAM_SYSTEM_ERR;
+        case ZFSCRYPT_ERR_OS:
+        case ZFSCRYPT_ERR_ZFS:
+            return PAM_SYSTEM_ERR;
+        case ZFSCRYPT_ERR_PAM:
+            return err.value;
+        default:
+            // unreachable
+            return PAM_SYSTEM_ERR;
     }
 }


### PR DESCRIPTION
This moves the default return value into the switch statement.

Always providing a default is a common coding style requirement, and I believe there are compiler warning flags to enforce that.

You may also want to indent everything inside the switch another level, rather than having the case & default on the same level as switch. But that's a stylistic choice.

Again, this is untested.