### PR TITLE
Simplify zfscrypt_context_log_err

### DIFF
--- a/src/zfscrypt_context.c
+++ b/src/zfscrypt_context.c
@@ -49,21 +49,25 @@ void zfscrypt_context_log(zfscrypt_context_t* self, const int level, const char*
 }
 
 zfscrypt_err_t zfscrypt_context_log_err(zfscrypt_context_t* self, zfscrypt_err_t err) {
+    const char* domain;
     const int level = err.value == 0 ? LOG_DEBUG : LOG_ERR;
     if (level == LOG_DEBUG && !self->debug) {
         return err;
     }
     switch (err.type) {
     case ZFSCRYPT_ERR_OS:
-        zfscrypt_context_log(self, level, "OS: %s: %s (%s:%d:%s)", err.message, err.description, err.file, err.line, err.function);
+        domain = "OS";
         break;
     case ZFSCRYPT_ERR_PAM:
-        zfscrypt_context_log(self, level, "PAM: %s: %s (%s:%d:%s)", err.message, err.description, err.file, err.line, err.function);
+        domain = "PAM";
         break;
     case ZFSCRYPT_ERR_ZFS:
-        zfscrypt_context_log(self, level, "ZFS: %s: %s (%s:%d:%s)", err.message, err.description, err.file, err.line, err.function);
+        domain = "ZFS";
         break;
+    default:
+        domain = "UNKNOWN";
     }
+    zfscrypt_context_log(self, level, "%s: %s: %s (%s:%d:%s)", domain, err.message, err.description, err.file, err.line, err.function);
     return err;
 }
 

--- a/src/zfscrypt_context.c
+++ b/src/zfscrypt_context.c
@@ -49,23 +49,24 @@ void zfscrypt_context_log(zfscrypt_context_t* self, const int level, const char*
 }
 
 zfscrypt_err_t zfscrypt_context_log_err(zfscrypt_context_t* self, zfscrypt_err_t err) {
-    const char* domain;
     const int level = err.value == 0 ? LOG_DEBUG : LOG_ERR;
     if (level == LOG_DEBUG && !self->debug) {
         return err;
     }
+    const char* domain = NULL;
     switch (err.type) {
-    case ZFSCRYPT_ERR_OS:
-        domain = "OS";
-        break;
-    case ZFSCRYPT_ERR_PAM:
-        domain = "PAM";
-        break;
-    case ZFSCRYPT_ERR_ZFS:
-        domain = "ZFS";
-        break;
-    default:
-        domain = "UNKNOWN";
+        case ZFSCRYPT_ERR_OS:
+            domain = "OS";
+            break;
+        case ZFSCRYPT_ERR_PAM:
+            domain = "PAM";
+            break;
+        case ZFSCRYPT_ERR_ZFS:
+            domain = "ZFS";
+            break;
+        default:
+            domain = "UNKNOWN";
+            break;
     }
     zfscrypt_context_log(self, level, "%s: %s: %s (%s:%d:%s)", domain, err.message, err.description, err.file, err.line, err.function);
     return err;


### PR DESCRIPTION
This eliminates the duplicated long zfscrypt_context_log calls in favor of a temporary variable.

This also adds a default to the switch.

Again, this is untested.