### PR TITLE
Clarify pam_sm_open_session

### DIFF
--- a/src/pam_zfscrypt.c
+++ b/src/pam_zfscrypt.c
@@ -93,7 +93,7 @@ extern int pam_sm_close_session(pam_handle_t* handle, int flags, int argc, char 
             zfscrypt_session_counter_update(&counter, context.runtime_dir, context.user, -1));
     }
     if (counter == 0) {
-	/* The last session has been closed. Unmount and lock the filesystems. */
+	// The last session has been closed. Unmount and lock the filesystems.
         if (!err.value)
             err = zfscrypt_context_drop_privs(&context);
         if (!err.value)

--- a/src/pam_zfscrypt.c
+++ b/src/pam_zfscrypt.c
@@ -64,7 +64,7 @@ extern int pam_sm_open_session(pam_handle_t* handle, int flags, int argc, char c
             zfscrypt_session_counter_update(&counter, context.runtime_dir, context.user, +1));
     }
     if (counter == 1) {
-        /* This is the first session for the user. Unlock and mount the filesystems. */
+        // This is the first session for the user. Unlock and mount the filesystems.
         if (!err.value)
             err = zfscrypt_context_drop_privs(&context);
         if (!err.value)


### PR DESCRIPTION
This eliminates duplicated `&& counter == 1` and adds a comment
explaining why that value is significant.

Again, this is untested.